### PR TITLE
Styling improvements

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -23,7 +23,7 @@ export default class Cell extends Component {
 
     render() {
         return (
-            <View style={style.cell} ref={this.updateCell.bind(this)}>
+            <View style={[style.cell, this.props.style]} ref={this.updateCell.bind(this)}>
                 {this.props.children}
             </View>
         );

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -92,7 +92,7 @@ export default class Grid extends Component {
             return <View style={style.grid}>{this.props.children}</View>;
         }
         return (
-            <View style={[style.grid, style.gridColumn]}>
+            <View style={[style.grid, style.gridColumn, this.props.style]}>
             {this.columns.map((col, i) => (
                 <View key={i} style={[style.column]}>
                 {col.map((cell, index) => (

--- a/src/style.js
+++ b/src/style.js
@@ -6,8 +6,7 @@ export default StyleSheet.create({
         flexDirection: 'column',
         alignItems: 'stretch',
         borderColor: 'lightgrey',
-        borderLeftWidth: 1,
-        borderBottomWidth: 1
+        borderWidth: 1,
     },
     gridColumn: {
         flexDirection: 'row'
@@ -20,13 +19,12 @@ export default StyleSheet.create({
         flexDirection: 'column',
         flexGrow: 1,
         flexShrink: 1,
-        borderColor: 'lightgrey',
-        borderRightWidth: 1
     },
     cell: {
         flexGrow: 1,
         padding: 4,
         borderColor: 'lightgrey',
-        borderTopWidth: 1
+        borderBottomWidth: 1,
+        borderRightWidth: 1,
     }
 });

--- a/src/style.js
+++ b/src/style.js
@@ -24,6 +24,7 @@ export default StyleSheet.create({
         borderRightWidth: 1
     },
     cell: {
+        flexGrow: 1,
         padding: 4,
         borderColor: 'lightgrey',
         borderTopWidth: 1


### PR DESCRIPTION
Hi there, thanks for the nifty library!

I've added support for specifying styles and fixed a minor bug (cell's weren't stretching).

The changes to the border styles are subtle, but allow for grid's exterior border to be styled independently of the interior.

Here's an example of what sort of styling this allows:

<img width="373" alt="screen shot 2017-03-13 at 1 59 06 am" src="https://cloud.githubusercontent.com/assets/482276/23832831/176804aa-0791-11e7-83ed-31d29f6b1bd7.png">

Or something a little less obnoxious:

<img width="374" alt="screen shot 2017-03-13 at 1 59 44 am" src="https://cloud.githubusercontent.com/assets/482276/23832832/21cb75ee-0791-11e7-8f8d-512984efbc8c.png">
